### PR TITLE
build scripts w/ moab and pymoab w/ python 2 and 3

### DIFF
--- a/pymoab-py2-18.04
+++ b/pymoab-py2-18.04
@@ -1,0 +1,57 @@
+FROM  ubuntu:18.04
+
+# set timezone
+ENV HOME /root
+ENV TZ=America/Chicago
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+ENV HOME /root
+
+RUN apt-get -y --force-yes update
+RUN apt-get install -y --force-yes \
+    software-properties-common \
+    build-essential \
+    git \
+    cmake \
+    gfortran \
+    libblas-dev \
+    python-pip \
+    liblapack-dev \
+    libhdf5-dev \
+    autoconf \
+    libtool
+
+# need to put libhdf5.so on LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu
+ENV LIBRARY_PATH /usr/lib/x86_64-linux-gnu
+
+# upgrade pip and install python dependencies
+ENV PATH $HOME/.local/bin:$PATH
+RUN python -m pip install --upgrade pip
+RUN pip install numpy scipy cython tables matplotlib setuptools future pytest
+
+# make starting directory
+RUN cd $HOME \
+  && mkdir opt
+
+# build MOAB
+RUN cd $HOME/opt \
+    && mkdir moab \
+    && cd moab \
+    && git clone https://bitbucket.org/fathomteam/moab \
+    && cd moab \
+    && git checkout -b Version5.1.0 origin/Version5.1.0 \
+    && autoreconf -fi \
+    && cd .. \
+    && mkdir build \
+    && cd build \
+    && ../moab/configure --enable-shared --enable-optimize --enable-pymoab --disable-debug --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial --prefix=$HOME/opt/moab \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -rf build moab
+
+# set environment variables
+ENV PATH $HOME/opt/moab/bin/:$PATH
+ENV LD_LIBRARY_PATH $HOME/opt/moab/lib:$LD_LIBRARY_PATH
+ENV PYTHONPATH $HOME/opt/moab/lib/python2.7/site-packages/:$PYTHONPATH

--- a/pymoab-py2-18.04
+++ b/pymoab-py2-18.04
@@ -7,19 +7,19 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 ENV HOME /root
 
-RUN apt-get -y --force-yes update
-RUN apt-get install -y --force-yes \
-    software-properties-common \
-    build-essential \
-    git \
-    cmake \
-    gfortran \
-    libblas-dev \
-    python-pip \
-    liblapack-dev \
-    libhdf5-dev \
-    autoconf \
-    libtool
+RUN apt-get -y --force-yes update \
+    && apt-get install -y --force-yes \
+       software-properties-common \
+       build-essential \
+       git \
+       cmake \
+       gfortran \
+       libblas-dev \
+       python-pip \
+       liblapack-dev \
+       libhdf5-dev \
+       autoconf \
+       libtool
 
 # need to put libhdf5.so on LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu
@@ -27,8 +27,8 @@ ENV LIBRARY_PATH /usr/lib/x86_64-linux-gnu
 
 # upgrade pip and install python dependencies
 ENV PATH $HOME/.local/bin:$PATH
-RUN python -m pip install --upgrade pip
-RUN pip install numpy scipy cython tables matplotlib setuptools future pytest
+RUN python -m pip install --upgrade pip \
+    && pip install numpy scipy cython tables matplotlib setuptools future pytest
 
 # make starting directory
 RUN cd $HOME \

--- a/pymoab-py2-18.04
+++ b/pymoab-py2-18.04
@@ -38,16 +38,15 @@ RUN cd $HOME \
 RUN cd $HOME/opt \
     && mkdir moab \
     && cd moab \
-    && git clone https://bitbucket.org/fathomteam/moab \
-    && cd moab \
-    && git checkout -b Version5.1.0 origin/Version5.1.0 \
-    && autoreconf -fi \
-    && cd .. \
+    && git clone --depth 1 -b Version5.1.0 --single-branch https://bitbucket.org/fathomteam/moab \
     && mkdir build \
     && cd build \
-    && ../moab/configure --enable-shared --enable-optimize --enable-pymoab --disable-debug --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial --prefix=$HOME/opt/moab \
-    && make \
-    && make install \
+    && cmake ../moab -DCMAKE_C_FLAGS="-fPIC -DPIC" -DCMAKE_CXX_FLAGS="-fPIC -DPIC" -DBUILD_SHARED_LIBS=ON \
+       -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--no-undefined" -DENABLE_MPI=OFF  \
+       -DENABLE_HDF5=ON -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial \
+       -DENABLE_NETCDF=OFF -DENABLE_METIS=OFF -DENABLE_IMESH=OFF -DENABLE_FBIGEOM=OFF \
+       -DENABLE_PYMOAB=ON -DPREFIX=$HOME/opt/moab \
+    && make all -j 8 \
     && cd .. \
     && rm -rf build moab
 

--- a/pymoab-py3-18.04
+++ b/pymoab-py3-18.04
@@ -1,0 +1,62 @@
+FROM  ubuntu:18.04
+
+# set timezone
+ENV HOME /root
+ENV TZ=America/Chicago
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+ENV HOME /root
+
+RUN apt-get -y --force-yes update
+RUN apt-get install -y --force-yes \
+    software-properties-common \
+    build-essential \
+    git \
+    cmake \
+    gfortran \
+    libblas-dev \
+    python3-pip \
+    liblapack-dev \
+    libhdf5-dev \
+    autoconf \
+    libtool
+
+# need to put libhdf5.so on LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu
+ENV LIBRARY_PATH /usr/lib/x86_64-linux-gnu
+
+# upgrade pip and install python dependencies
+ENV PATH $HOME/.local/bin:$PATH
+
+
+RUN python3 -m pip install --upgrade pip
+RUN pip install numpy scipy cython tables matplotlib setuptools future pytest
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
+    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10;
+
+# make starting directory
+RUN cd $HOME \
+  && mkdir opt
+
+# build MOAB
+RUN cd $HOME/opt \
+    && mkdir moab \
+    && cd moab \
+    && git clone https://bitbucket.org/fathomteam/moab \
+    && cd moab \
+    && git checkout -b Version5.1.0 origin/Version5.1.0 \
+    && autoreconf -fi \
+    && cd .. \
+    && mkdir build \
+    && cd build \
+    && ../moab/configure --enable-shared --enable-optimize --enable-pymoab --disable-debug --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial --prefix=$HOME/opt/moab \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -rf build moab
+
+# set environment variables
+ENV PATH $HOME/opt/moab/bin/:$PATH
+ENV LD_LIBRARY_PATH $HOME/opt/moab/lib:$LD_LIBRARY_PATH
+ENV PYTHONPATH $HOME/opt/moab/lib/python3.6/site-packages/:$PYTHONPATH

--- a/pymoab-py3-18.04
+++ b/pymoab-py3-18.04
@@ -7,19 +7,19 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 ENV HOME /root
 
-RUN apt-get -y --force-yes update
-RUN apt-get install -y --force-yes \
-    software-properties-common \
-    build-essential \
-    git \
-    cmake \
-    gfortran \
-    libblas-dev \
-    python3-pip \
-    liblapack-dev \
-    libhdf5-dev \
-    autoconf \
-    libtool
+RUN apt-get -y --force-yes update \
+    && apt-get install -y --force-yes \
+       software-properties-common \
+       build-essential \
+       git \
+       cmake \
+       gfortran \
+       libblas-dev \
+       python3-pip \
+       liblapack-dev \
+       libhdf5-dev \
+       autoconf \
+       libtool
 
 # need to put libhdf5.so on LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu
@@ -31,8 +31,8 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10;
 
 # upgrade pip and install python dependencies
-RUN python -m pip install --upgrade pip
-RUN pip install numpy scipy cython tables matplotlib setuptools future pytest
+RUN python -m pip install --upgrade pip \
+    && pip install numpy scipy cython tables matplotlib setuptools future pytest
 
 
 # make starting directory

--- a/pymoab-py3-18.04
+++ b/pymoab-py3-18.04
@@ -24,16 +24,16 @@ RUN apt-get install -y --force-yes \
 # need to put libhdf5.so on LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu
 ENV LIBRARY_PATH /usr/lib/x86_64-linux-gnu
-
-# upgrade pip and install python dependencies
 ENV PATH $HOME/.local/bin:$PATH
 
-
-RUN python3 -m pip install --upgrade pip
-RUN pip install numpy scipy cython tables matplotlib setuptools future pytest
-
+# switch to python 3
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10;
+
+# upgrade pip and install python dependencies
+RUN python -m pip install --upgrade pip
+RUN pip install numpy scipy cython tables matplotlib setuptools future pytest
+
 
 # make starting directory
 RUN cd $HOME \
@@ -43,16 +43,15 @@ RUN cd $HOME \
 RUN cd $HOME/opt \
     && mkdir moab \
     && cd moab \
-    && git clone https://bitbucket.org/fathomteam/moab \
-    && cd moab \
-    && git checkout -b Version5.1.0 origin/Version5.1.0 \
-    && autoreconf -fi \
-    && cd .. \
+    && git clone --depth 1 -b Version5.1.0 --single-branch https://bitbucket.org/fathomteam/moab \
     && mkdir build \
     && cd build \
-    && ../moab/configure --enable-shared --enable-optimize --enable-pymoab --disable-debug --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial --prefix=$HOME/opt/moab \
-    && make \
-    && make install \
+    && cmake ../moab -DCMAKE_C_FLAGS="-fPIC -DPIC" -DCMAKE_CXX_FLAGS="-fPIC -DPIC" -DBUILD_SHARED_LIBS=ON \
+       -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--no-undefined" -DENABLE_MPI=OFF  \
+       -DENABLE_HDF5=ON -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial \
+       -DENABLE_NETCDF=OFF -DENABLE_METIS=OFF -DENABLE_IMESH=OFF -DENABLE_FBIGEOM=OFF \
+       -DENABLE_PYMOAB=ON -DPREFIX=$HOME/opt/moab \
+    && make all -j 8 \
     && cd .. \
     && rm -rf build moab
 


### PR DESCRIPTION
Using these build scripts for images in DAGMC Stats testing

Contains: MOAB w/ PyMOAB enabled on 18.04. One is w/ python 2 and one is with python 3.