### PR TITLE
pymoab image fixes

### DIFF
--- a/pymoab-py2-18.04
+++ b/pymoab-py2-18.04
@@ -47,7 +47,9 @@ RUN cd $HOME/opt \
        -DENABLE_NETCDF=OFF -DENABLE_METIS=OFF -DENABLE_IMESH=OFF -DENABLE_FBIGEOM=OFF \
        -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
     && make all -j 8 \
-    && make install
+    && make install \
+    && cd $HOME/opt/moab \
+    && rm -rf build moab
 
 # set environment variables
 ENV PATH $HOME/opt/moab/bin/:$PATH

--- a/pymoab-py2-18.04
+++ b/pymoab-py2-18.04
@@ -45,10 +45,9 @@ RUN cd $HOME/opt \
        -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--no-undefined" -DENABLE_MPI=OFF  \
        -DENABLE_HDF5=ON -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial \
        -DENABLE_NETCDF=OFF -DENABLE_METIS=OFF -DENABLE_IMESH=OFF -DENABLE_FBIGEOM=OFF \
-       -DENABLE_PYMOAB=ON -DPREFIX=$HOME/opt/moab \
+       -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
     && make all -j 8 \
-    && cd .. \
-    && rm -rf build moab
+    && make install
 
 # set environment variables
 ENV PATH $HOME/opt/moab/bin/:$PATH

--- a/pymoab-py2-18.04
+++ b/pymoab-py2-18.04
@@ -46,7 +46,7 @@ RUN cd $HOME/opt \
        -DENABLE_HDF5=ON -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial \
        -DENABLE_NETCDF=OFF -DENABLE_METIS=OFF -DENABLE_IMESH=OFF -DENABLE_FBIGEOM=OFF \
        -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
-    && make all -j 8 \
+    && make -j 8 \
     && make install \
     && cd $HOME/opt/moab \
     && rm -rf build moab

--- a/pymoab-py3-18.04
+++ b/pymoab-py3-18.04
@@ -52,7 +52,9 @@ RUN cd $HOME/opt \
        -DENABLE_NETCDF=OFF -DENABLE_METIS=OFF -DENABLE_IMESH=OFF -DENABLE_FBIGEOM=OFF \
        -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
     && make -j 8 \
-    && make install
+    && make install \
+    && cd $HOME/opt/moab \
+    && rm -rf build moab
 
 # set environment variables
 ENV PATH $HOME/opt/moab/bin/:$PATH

--- a/pymoab-py3-18.04
+++ b/pymoab-py3-18.04
@@ -50,10 +50,9 @@ RUN cd $HOME/opt \
        -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--no-undefined" -DENABLE_MPI=OFF  \
        -DENABLE_HDF5=ON -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial \
        -DENABLE_NETCDF=OFF -DENABLE_METIS=OFF -DENABLE_IMESH=OFF -DENABLE_FBIGEOM=OFF \
-       -DENABLE_PYMOAB=ON -DPREFIX=$HOME/opt/moab \
-    && make all -j 8 \
-    && cd .. \
-    && rm -rf build moab
+       -DENABLE_PYMOAB=ON -DCMAKE_INSTALL_PREFIX=$HOME/opt/moab \
+    && make -j 8 \
+    && make install
 
 # set environment variables
 ENV PATH $HOME/opt/moab/bin/:$PATH


### PR DESCRIPTION
Multiple errors were in the previous versions for the pymoab images. This PR fixes those:

- previously accidentally removed the build/install folders- no longer removed
- uses the correct CMake variable for the install prefix
- actually runs make install