### PR TITLE
Added missing package to pymoab-visit image

### DIFF
--- a/pymoab-visit-py2-18.04
+++ b/pymoab-visit-py2-18.04
@@ -9,7 +9,8 @@ RUN apt-get -y --force-yes update \
     libgl1-mesa-dev \
     libsm6 \
     libxt6 \
-    libglu1-mesa
+    libglu1-mesa \
+    libharfbuzz-dev
 
 RUN pip install xmldiff
 
@@ -24,4 +25,3 @@ RUN cd $HOME/opt \
 ENV PATH /usr/local/visit/bin:$PATH
 ENV LD_LIBRARY_PATH /usr/local/visit/3.1.1/linux-x86_64/lib/:$LD_LIBRARY_PATH
 ENV PYTHONPATH /usr/local/visit/3.1.1/linux-x86_64/lib/site-packages:$PYTHONPATH
-


### PR DESCRIPTION
I added the `libharfbuzz-dev` package to the `pymoab-visit-py2-18.04` image in order to prevent VisIt from stalling indefinitely if it is started with the `LaunchNowin` command in a python environment.