### PR TITLE
Adding github actions to build and publish docker images on dockerhub

### DIFF
--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -14,10 +14,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Publish to Registry
+
+    - name: Publish pymoab-py2-18.04 to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: shimwell/pymoab-py2-18.04
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: pymoab-py2-18.04/Dockerfile
+
+    - name: Publish pymoab-py3-18.04 to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: shimwell/pymoab-py3-18.04
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: pymoab-py3-18.04/Dockerfile
+
+    - name: Publish pymoab-visit-py2-18.04 to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: shimwell/pymoab-visit-py2-18.04
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: pymoab-visit-py2-18.04/Dockerfile

--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -12,29 +12,22 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        : [
+          pymoab-py2-18.04,
+          pymoab-py3-18.04,
+          pymoab-visit-py2-18.04,
+        ]
+        
     steps:
     - uses: actions/checkout@master
 
-    - name: Publish pymoab-py2-18.04 to Registry
+    - name: Publish ${{ matrix.name }} to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: shimwell/pymoab-py2-18.04
+        name: shimwell/${{ matrix.name }}
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: pymoab-py2-18.04/Dockerfile
-
-    - name: Publish pymoab-py3-18.04 to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: shimwell/pymoab-py3-18.04
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: pymoab-py3-18.04/Dockerfile
-
-    - name: Publish pymoab-visit-py2-18.04 to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: shimwell/pymoab-visit-py2-18.04
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: pymoab-visit-py2-18.04/Dockerfile
+        dockerfile: ${{ matrix.name }}/Dockerfile

--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -1,0 +1,23 @@
+# This yml file will trigger a Github Action on pushes to the main branch.
+# This Action will build and upload a Docker image to Dockerhub
+# https://github.com/marketplace/actions/publish-docker
+
+name: dockerhub-publish
+
+on:
+  push:
+    branches: 
+    - main
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: shimwell/pymoab-py2-18.04
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: pymoab-py2-18.04/Dockerfile

--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Publish ${{ matrix.name }} to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: shimwell/${{ matrix.name }}
+        name: svalinn/${{ matrix.name }}
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: ${{ matrix.name }}/Dockerfile

--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        : [
+       name : [
           pymoab-py2-18.04,
           pymoab-py3-18.04,
           pymoab-visit-py2-18.04,

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # dockerfile
 Host all the docker file used in the `svalinn` workflows, CI....
+
+Pushing to the main branch of this repository triggers a rebuild of all
+dockerfiles in the repository and publishing of the resulting docker images on
+the [Svalinn DockerHub](https://hub.docker.com/u/svalinn) with the tags:
+
+- [pymoab-py2-18.04](https://hub.docker.com/r/svalinn/pymoab-py2-18.04)
+- [pymoab-py3-18.04](https://hub.docker.com/r/svalinn/pymoab-py2-18.04)
+- [pymoab-visit-py2-18.04](https://hub.docker.com/r/svalinn/pymoab-py2-18.04)


### PR DESCRIPTION
This PR adds GitHub actions to automate the building of the dockerfiles in this repository and publishing on dockerhub

for this to work two repository secrets will need to be added as the action makes use of ...
```
        username: ${{ secrets.DOCKER_USERNAME }}
        password: ${{ secrets.DOCKER_PASSWORD }}
```

You can see from the github action runs on my fork that this has been successfully building the three images 

https://github.com/Shimwell/dockerfiles/actions

They were also uploaded to my dockerhub just to test https://hub.docker.com/u/shimwell

Naturally this GitHub action will upload to the Svalinn dockerhub but I just wanted to check everything works