### PR TITLE
Adding github actions to build and publish docker images on GH packages

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -46,4 +46,4 @@ jobs:
           file: ${{ env.name_visit}}/Dockerfile
           context: .
           push: true
-          tags: ghcr.io/svalinn/pymoab-visit-py2-18.04
+          tags: ghcr.io/svalinn/${{ env.name_visit}}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -33,11 +33,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.REGISTRY }}/${{ matrix.name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -3,16 +3,9 @@ on:
   push:
     branches: ['gh_action_gh_container_registry']  # todo replace with main once we know this is working
 
-env:
-  REGISTRY: 
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     strategy:
       matrix:
@@ -25,11 +18,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Log in to the Container registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push pymoab Docker image
@@ -38,8 +34,8 @@ jobs:
           file: ${{ matrix.name }}/Dockerfile
           context: .
           push: true
-          tags: ${{ matrix.name }}
- 
+          tags: ghcr.io/svalinn/${{ matrix.name }}
+
         if: success()
       - name: Build and push visit Docker image
         uses: docker/build-push-action@v2
@@ -47,5 +43,4 @@ jobs:
           file: pymoab-visit-py2-18.04/Dockerfile
           context: .
           push: true
-          tags: pymoab-visit-py2-18.04
- 
+          tags: ghcr.io/svalinn/pymoab-visit-py2-18.04

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,7 +1,7 @@
 
 on:
   push:
-    branches: ['gh_action_gh_container_registry']
+    branches: ['gh_action_gh_container_registry']  # todo replace with main once we know this is working
 
 env:
   REGISTRY: 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -7,6 +7,9 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
 
+    env:
+      name_visit: pymoab-visit-py2-18.04
+
     strategy:
       matrix:
        name : [
@@ -40,7 +43,7 @@ jobs:
       - name: Build and push visit Docker image
         uses: docker/build-push-action@v2
         with:
-          file: pymoab-visit-py2-18.04/Dockerfile
+          file: ${{ env.name_visit}}/Dockerfile
           context: .
           push: true
           tags: ghcr.io/svalinn/pymoab-visit-py2-18.04

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,7 +1,7 @@
 
 on:
   push:
-    branches: ['gh_action_gh_container_registry']  # todo replace with main once we know this is working
+    branches: ['main']
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,0 +1,49 @@
+
+on:
+  push:
+    branches: ['gh_action_gh_container_registry']
+
+env:
+  REGISTRY: 
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+       name : [
+          pymoab-py2-18.04,
+          pymoab-py3-18.04,
+          pymoab-visit-py2-18.04,
+        ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ matrix.name }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          file: ${{ matrix.name }}/Dockerfile
+          context: .
+          push: true
+          tags: ${{ matrix.name }}
+ 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -19,8 +19,7 @@ jobs:
        name : [
           pymoab-py2-18.04,
           pymoab-py3-18.04,
-          pymoab-visit-py2-18.04,
-        ]
+          ]
 
     steps:
       - name: Checkout repository
@@ -33,7 +32,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
@@ -41,4 +39,13 @@ jobs:
           context: .
           push: true
           tags: ${{ matrix.name }}
+ 
+        if: success()
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          file: pymoab-visit-py2-18.04/Dockerfile
+          context: .
+          push: true
+          tags: pymoab-visit-py2-18.04
  

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -7,9 +7,6 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
 
-    env:
-      name_visit: pymoab-visit-py2-18.04
-
     strategy:
       matrix:
        name : [
@@ -41,6 +38,8 @@ jobs:
 
         if: success()
       - name: Build and push visit Docker image
+        env:
+          name_visit: pymoab-visit-py2-18.04
         uses: docker/build-push-action@v2
         with:
           file: ${{ env.name_visit}}/Dockerfile

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -32,7 +32,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push pymoab Docker image
         uses: docker/build-push-action@v2
         with:
           file: ${{ matrix.name }}/Dockerfile
@@ -41,7 +41,7 @@ jobs:
           tags: ${{ matrix.name }}
  
         if: success()
-      - name: Build and push Docker image
+      - name: Build and push visit Docker image
         uses: docker/build-push-action@v2
         with:
           file: pymoab-visit-py2-18.04/Dockerfile

--- a/pymoab-visit-py2-18.04/Dockerfile
+++ b/pymoab-visit-py2-18.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM svalinn/pymoab-py2-18.04:latest
+FROM ghcr.io/svalinn/pymoab-py2-18.04:latest
 
 RUN apt-get -y --force-yes update \
     && apt-get install -y --fix-missing \


### PR DESCRIPTION
This is a PR to add a GitHub action that builds three docker images and uploads them to the GitHub packages (container registry section)

I followed the example workflow provided by GitHub https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-github-packages

For this to work a new secret will need to be added to the repo by someone with admin permissions

The secret should be a GITHUB_TOKEN which can be generated here https://github.com/settings/tokens/506109284

